### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,39 @@ curl https://binaries.hyperliquid.xyz/Testnet/hl-visor > ~/hl-visor && chmod a+x
 ```
 
 ## Running
-Run `~/hl-visor`. It may take a while as your node navigates the network to find an appropriate peer to stream from. Once you see logs like `applied block X` then your node should be streaming live data. You can inspect the transactions or other data as described below.
+By using screen, you can maintain persistent terminal sessions even after disconnecting, ensuring that your processes continue to run uninterrupted. Follow the steps below to set up and use screen to manage your session effectively.
+Ensure you have completed the setup session mentioned above before proceeding.
+
+### Step 1: Update and Install Screen
+First, update your package lists and install screen:
+```
+sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get install screen -y
+```
+
+### Step 2: Create a Screen Session
+Now that the installation is complete, create a new screen session. In this example, we will name the session hl:
+```
+screen -S hl
+```
+
+### Step 3: Launch the Hyperliquid Node
+Within the newly created screen session, launch the hyperliquid node:
+```
+~/hl-visor
+```
+
+### Step 4: Detach from the Screen Session
+To detach from the current screen session (named hl) without terminating it, press Ctrl+a followed by d.
+
+### Step 5: Reattach to the Screen Session
+If you need to return to the screen session, use the following command:
+```
+screen -r hl
+```
+
+By following these steps, you can ensure that your node continues to run seamlessly, even if you disconnect from your terminal session.
+
 
 ## Reading L1 data
 The node process will write data to `~/hl/data`. With default settings, the network will generate around 20 gb of logs per day, so it is also recommended to archive or delete old files.


### PR DESCRIPTION
Added a guide on using the `screen` tool to run the Hyperliquid node effectively. By using `screen`, you can maintain persistent terminal sessions even after disconnecting, ensuring that your processes continue to run uninterrupted. This helps in running the node reliably.

Key changes:
1. Added instructions for installing and setting up the `screen` tool.
2. Explained how to create, detach, and reattach `screen` sessions.
3. Detailed steps to run the Hyperliquid node within a `screen` session.

This update will assist users in managing and running their nodes more efficiently.
