### PR TITLE
add new launch syntax to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,5 @@ ADD --chown=$USER_UID:$USER_GID --chmod=700 https://binaries.hyperliquid.xyz/Tes
 EXPOSE 9000
 EXPOSE 8000
 
-ENTRYPOINT $HOME/hl-visor
+# run a non-validating node
+ENTRYPOINT $HOME/hl-visor run-non-validator


### PR DESCRIPTION
Modify Dockerfile to accommodate new launch syntax of `run-non-validator`