### PR TITLE
docs: update min self-delegation requirement for testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ These command print the addresses:
 ```
 
 ### Join network
-During the initial phase of testing, the validator address from the previous step needs to be whitelisted.
+During the initial phase of testing, the validator address from the previous step needs to be whitelisted. The validator set on testnet is entirely permissionless.
 
-Register public IP and signer address of validator, along with display name and description. On testnet, self-delegate 1 HYPE to run the validator.
+Register public IP and signer address of validator, along with display name and description. On testnet, self-delegate 10_000 HYPE to run the validator.
 ```
-~/hl-node --chain Testnet --key <validator-key> send-signed-action '{"type": "CValidatorAction", "register": {"profile": {"node_ip": {"Ip": "1.2.3.4"}, "signer": "<signer-address>", "name": "...", "description": "..." }, "initial_wei": 100000}}'
+~/hl-node --chain Testnet --key <validator-key> send-signed-action '{"type": "CValidatorAction", "register": {"profile": {"node_ip": {"Ip": "1.2.3.4"}, "signer": "<signer-address>", "name": "...", "description": "..." }, "initial_wei": 1000000000000}}'
 ```
 
 Make sure ports 4000-4010 are open to other validators (currently only ports 4001-4006 are used, but additional ports in the range 4000-4010 may be used in the future). Either open the ports to the public, or keep a firewall allowing the validators which are found in `c_staking` in the state snapshots. Note that the validator set and IPs are dynamic.


### PR DESCRIPTION
<img width="736" alt="image" src="https://github.com/user-attachments/assets/9384189e-87dc-49e8-85cb-5c53d9881534" />

Hopefully this helps folks who may have missed the message in discord but check the Github. If the 10K self-delegation is not in place and someone tries to go live, they may run into errors but as far as I could tell, none of the errors directly mentioned this requirement as being unfulfilled.