### PR TITLE
fix: protect files in excluded dirs from deletions

### DIFF
--- a/pruner/scripts/prune.sh
+++ b/pruner/scripts/prune.sh
@@ -21,15 +21,15 @@ size_before=$(du -sh "$DATA_PATH" | cut -f1)
 files_before=$(find "$DATA_PATH" -type f | wc -l)
 echo "$(date): Size before pruning: $size_before with $files_before files" >> /proc/1/fd/1
 
-# Build the exclusion part of the find command
-EXCLUDE_EXPR=""
-for name in "${EXCLUDES[@]}"; do
-    EXCLUDE_EXPR+=" ! -name \"$name\""
+# Build the -prune arguments for excluding directories
+PRUNE_ARGS=()
+for dir in "${EXCLUDES[@]}"; do
+    PRUNE_ARGS+=(-path "*/$dir" -prune -o)
 done
 
 # Delete data older than 48 hours = 60 minutes * 48 hours
 HOURS=$((60*48))
-eval "find \"$DATA_PATH\" -mindepth 1 -depth -mmin +$HOURS -type f $EXCLUDE_EXPR -delete"
+find "$DATA_PATH" -mindepth 1 "${PRUNE_ARGS[@]}" -type f -mmin +$HOURS -exec rm {} +
 
 # Get directory size after pruning
 size_after=$(du -sh "$DATA_PATH" | cut -f1)


### PR DESCRIPTION
Previous fix only excluded **directories by name**, allowing files within to be deleted.

Changed to use -prune to skip entire directory subtrees from evaluation given a match on `$EXCLUDES`
- Changed from ! -name "dir" to -path "*/dir" -prune -o  
- Files under excluded directories (e.g., visor_child_stderr) are now protected

---

previous - note: `old.log` gets deleted within protected dirs `visor_child_stderr` `20250530`:
<img width="996" alt="image" src="https://github.com/user-attachments/assets/c1ada36d-1a1e-4c48-bc34-2d6413044f10" />

---
now:
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/a05f4917-003f-4631-b6f2-2e8cef4279d1" />

