### PR TITLE
feat: Make pruner script configurable via environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ services:
     build: ./pruner
     volumes:
       - hl-data:/home/hluser/hl/data
+    # Optional environment variables to customize pruning behavior
+    # environment:
+    #   - DATA_PATH=/home/hluser/hl/data              # Path to data directory (default: /home/hluser/hl/data)
+    #   - PRUNE_DAYS=2                                # Number of days to keep files (default: 2)
+    #   - PRUNE_EXCLUDES=visor_child_stderr,logs      # Comma-separated list of files/folders to exclude (default: visor_child_stderr)
 
 
 volumes:

--- a/pruner/Dockerfile
+++ b/pruner/Dockerfile
@@ -4,6 +4,11 @@ ARG USERNAME=hluser
 ARG USER_UID=10000
 ARG USER_GID=$USER_UID
 
+# Environment variables for pruner configuration (can be overridden at runtime)
+ENV DATA_PATH=/home/hluser/hl/data
+ENV PRUNE_DAYS=2
+ENV PRUNE_EXCLUDES=visor_child_stderr
+
 # create custom user, install dependencies, create data directory
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \


### PR DESCRIPTION
## Summary
This PR enhances the pruner script to support configuration via environment variables, making it more flexible for different deployment environments  without requiring container rebuilds.

## Changes Made
- **Environment Variable Support**: Added support for `DATA_PATH`, `PRUNE_DAYS`, and `PRUNE_EXCLUDES` with sensible defaults 
- **Day-based Configuration**: Replaced hardcoded 48-hour retention with configurable `PRUNE_DAYS` (default: 2 days)
- **Flexible Exclusions**: Support comma-separated list in `PRUNE_EXCLUDES` for multiple file/folder exclusions
- **Enhanced Logging**: Added configuration logging for better debugging and transparency
- **Docker Integration**: Updated Dockerfile and docker-compose.yml with example configurations

## Environment Variables
- `DATA_PATH` - Path to data directory (default: `/home/hluser/hl/data`)
- `PRUNE_DAYS` - Number of days to retain files (default: `2`)
- `PRUNE_EXCLUDES` - Comma-separated list of files/folders to exclude (default: `visor_child_stderr`)

## Usage Examples
**Docker Compose:**
```yaml 
environment:
  - PRUNE_DAYS=7
  - PRUNE_EXCLUDES=visor_child_stderr,logs,backups
```
**Docker Run:**
docker run -e PRUNE_DAYS=7 -e PRUNE_EXCLUDES=visor_child_stderr,logs

## Backward Compatibility

All changes maintain full backward compatibility. Existing deployments will continue to work with the same behavior (2-day retention, excluding visor_child_stderr).