### PR TITLE
fix: revert to original fullnode ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ The validator community also runs several independent root peers for non-validat
 | Hyperbeat x P2P.org x Hypio   | 199.254.199.54  | Japan          |
 | Luganodes                     | 45.250.255.111  | Japan          |
 | Luganodes                     | 109.94.99.131   | Japan          |
-| HypurrCorea: SKYGG x DeSpread | 8.216.33.221    | Japan          |
+| HypurrCorea: SKYGG x DeSpread | 23.81.41.3      | Japan          |
 | HypurrCorea: SKYGG x DeSpread | 15.235.231.247  | Singapore      |
 | Purrposeful x HyBridge x PiP  | 199.254.199.48  | Japan          |
 | Purrposeful x HyBridge x PiP  | 199.254.199.52  | Japan          |


### PR DESCRIPTION
The provider's maintenance has been completed.
So we're reverting the fullnode IP back to its original one.